### PR TITLE
Rewrite post titles when items are sent to paypal

### DIFF
--- a/qtranslate-support-for-woocommerce.php
+++ b/qtranslate-support-for-woocommerce.php
@@ -106,3 +106,18 @@ function qwc_post_type_link($post_link, $post) {
 	}
 	return $post_link;
 }
+
+/*
+* Rewrite post titles when items are sent to paypal during checkout
+* Use current language if found, if not use default language
+*/
+function woocommerce_paypal_qtranslate_product_name($paypal_args){
+	$lang = qtrans_getLanguage();
+	foreach($paypal_args as $key=>$value){
+		if(strpos($key, 'item_name_') !== false){
+			$paypal_args[$key] = qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage($paypal_args[$key]);
+		}
+	}
+	return $paypal_args;
+}
+add_filter( 'woocommerce_paypal_args', 'woocommerce_paypal_qtranslate_product_name' );


### PR DESCRIPTION
As discussed here: https://github.com/mweimerskirch/wordpress-qtranslate-support-for-woocommerce/issues/13
